### PR TITLE
ENG-664: support using oneof value instead of separating values

### DIFF
--- a/python/google/protobuf/__init__.py
+++ b/python/google/protobuf/__init__.py
@@ -30,4 +30,4 @@
 
 # Copyright 2007 Google Inc. All Rights Reserved.
 
-__version__ = '4.22.0'
+__version__ = '4.22.0+sm1dev'

--- a/python/google/protobuf/__init__.py
+++ b/python/google/protobuf/__init__.py
@@ -30,4 +30,4 @@
 
 # Copyright 2007 Google Inc. All Rights Reserved.
 
-__version__ = '4.22.0+sm1dev'
+__version__ = '4.22.0+sm1'

--- a/python/google/protobuf/json_format.py
+++ b/python/google/protobuf/json_format.py
@@ -91,6 +91,7 @@ class ParseError(Error):
 def MessageToJson(
     message,
     including_default_value_fields=False,
+    use_oneof_name=False,
     preserving_proto_field_name=False,
     indent=2,
     sort_keys=False,
@@ -125,6 +126,7 @@ def MessageToJson(
   """
   printer = _Printer(
       including_default_value_fields,
+      use_oneof_name,
       preserving_proto_field_name,
       use_integers_for_enums,
       descriptor_pool,
@@ -135,6 +137,7 @@ def MessageToJson(
 def MessageToDict(
     message,
     including_default_value_fields=False,
+    use_oneof_name=False,
     preserving_proto_field_name=False,
     use_integers_for_enums=False,
     descriptor_pool=None,
@@ -162,6 +165,7 @@ def MessageToDict(
   """
   printer = _Printer(
       including_default_value_fields,
+      use_oneof_name,
       preserving_proto_field_name,
       use_integers_for_enums,
       descriptor_pool,


### PR DESCRIPTION
Given a protobuf format like this using the `oneof` feature:
```
        oneof value {
            uint32   int_value                      = 10;
            uint64   long_value                     = 11;
            float    float_value                    = 12;
            double   double_value                   = 13;
            bool     boolean_value                  = 14;
            string   string_value                   = 15;
            bytes    bytes_value                    = 16;       // Bytes, File
            DataSet  dataset_value                  = 17;
            Template template_value                 = 18;
            MetricValueExtension extension_value    = 19;
        }
```
The current json_format methods in the protobuf lib can lead to field names like:
* int_value
* long_value
* float_value
* ...

but we really just want them all to be the name "value." Unfortunately, their library and the protobuf schema doesn't provide an option to do this.

The good news is it's not too hard to add in so the code effort here is pretty minor.